### PR TITLE
Add survivor placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,10 +23,7 @@
     
 
     <div class="index-survivor-grid">
-      <a
-        href="survivors/railgunner.html"
-        class="index-survivor-card railgunner"
-      >
+      <a href="survivors/railgunner.html" class="index-survivor-card railgunner">
         <img src="images/Survivor_Icons/railgunner-icon.png" alt="Railgunner" />
         <h2>Railgunner</h2>
       </a>
@@ -34,6 +31,61 @@
       <a href="survivors/loader.html" class="index-survivor-card loader">
         <img src="images/Survivor_Icons/loader-icon.png" alt="Loader" />
         <h2>Loader</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=Commando" class="index-survivor-card">
+        <img src="images/Survivor_Icons/commando-icon.png" alt="Commando" />
+        <h2>Commando</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=Huntress" class="index-survivor-card">
+        <img src="images/Survivor_Icons/huntress-icon.png" alt="Huntress" />
+        <h2>Huntress</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=Bandit" class="index-survivor-card">
+        <img src="images/Survivor_Icons/bandit-icon.png" alt="Bandit" />
+        <h2>Bandit</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=Artificer" class="index-survivor-card">
+        <img src="images/Survivor_Icons/artificer-icon.png" alt="Artificer" />
+        <h2>Artificer</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=MUL-T" class="index-survivor-card">
+        <img src="images/Survivor_Icons/mulT-icon.png" alt="MUL-T" />
+        <h2>MUL-T</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=Engineer" class="index-survivor-card">
+        <img src="images/Survivor_Icons/engineer-icon.png" alt="Engineer" />
+        <h2>Engineer</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=Mercenary" class="index-survivor-card">
+        <img src="images/Survivor_Icons/mercenary-icon.png" alt="Mercenary" />
+        <h2>Mercenary</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=REX" class="index-survivor-card">
+        <img src="images/Survivor_Icons/rex-icon.png" alt="REX" />
+        <h2>REX</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=Acrid" class="index-survivor-card">
+        <img src="images/Survivor_Icons/acrid-icon.png" alt="Acrid" />
+        <h2>Acrid</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=Heretic" class="index-survivor-card">
+        <img src="images/Survivor_Icons/heretic-icon.png" alt="Heretic" />
+        <h2>Heretic</h2>
+      </a>
+
+      <a href="survivors/comingSoon.html?survivor=Void%20Fiend" class="index-survivor-card">
+        <img src="images/Survivor_Icons/voidFiend-icon.png" alt="Void Fiend" />
+        <h2>Void Fiend</h2>
       </a>
     </div>
   </body>

--- a/survivors/comingSoon.html
+++ b/survivors/comingSoon.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Calculator Coming Soon</title>
+    <link rel="stylesheet" href="../styles/global.css" />
+    <link rel="stylesheet" href="../styles/navbar.css" />
+  </head>
+  <body>
+    <div class="navbar enhanced-navbar">
+      <a href="../index.html" class="nav-back">
+        <span class="arrow">←</span> Back to Survivors
+      </a>
+      <div class="nav-center">
+        <img id="survivor-icon" class="nav-icon" />
+        <h1 class="nav-title" id="page-title"></h1>
+      </div>
+    </div>
+    <div style="padding:2rem;text-align:center;">
+      <p id="message">This survivor's calculator is coming soon.</p>
+    </div>
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const name = params.get('survivor') || 'Unknown';
+      document.getElementById('page-title').textContent = `${name} Calculator`;
+      const icon = document.getElementById('survivor-icon');
+      const imgName = name.replace(/\s+/g, '') + '-icon.png';
+      icon.src = `../images/Survivor_Icons/${imgName}`;
+      icon.alt = name;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add placeholder page for unimplemented survivors
- link remaining survivor icons from the index to placeholder page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684025784c1483318acff508e8fdbbcb